### PR TITLE
Download each version to its own directory

### DIFF
--- a/git-grab
+++ b/git-grab
@@ -403,7 +403,7 @@ if args.action == "download" or args.action == "view":
 
 			# Now write it to a file
 			if args.action == "download":
-				outfile=f"{outdir}/{entry['name']}"
+				outfile=f"{outdir}/{first}/{rest}/{entry['name']}"
 				if not os.path.exists(os.path.dirname(outfile)):
 					os.makedirs(os.path.dirname(outfile))
 				output=open(outfile,"wb")

--- a/git-grab
+++ b/git-grab
@@ -413,6 +413,9 @@ if args.action == "download" or args.action == "view":
 				output.close()
 			else:
 				data=decompressed[decompressed.find(b'\0')+1:].decode()
+				print("---------")
+				print(f"Viewing version {first}{rest}")
+				print("---------")
 				print(data)
 	exit(0)
 


### PR DESCRIPTION
If you download multiple versions of a file, you currently dump them over the top of each other. This may not be the best way to fix it, but it is one way to give the user each copy of the file.